### PR TITLE
Server crash due to mimetype with newline

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -308,6 +308,8 @@ upload = (user, objtype, objid, req, res) ->
     mimetype = null
     process.execFile '/usr/bin/file', ['-bi', req.files.files.path], (err, stdout) ->
       mimetype = unless err then stdout.toString()
+	  if mimetype.indexOf "\n"
+	    mimetype = mimetype.substr 0, mimetype.indexOf "\n"
 
       file = {
         name: req.files.files.name,


### PR DESCRIPTION
The mimetype string that is saved to the DB has a trailing newline-char.
This leads to the server crashing, when trying to download a file.